### PR TITLE
Fix code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Fixes [https://github.com/mpreston88/DevSecOps/security/code-scanning/6](https://github.com/mpreston88/DevSecOps/security/code-scanning/6)

To fix the problem, we need to enable CSRF protection in the `WebSecurityConfig` class. This involves removing the `csrf().disable()` call from the `configure` method. By doing this, we ensure that CSRF protection is enabled, which helps prevent CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
